### PR TITLE
DataCache: Changed a RNG seed for better memory efficiency

### DIFF
--- a/src/main/java/hr/irb/fastRandomForest/DataCache.java
+++ b/src/main/java/hr/irb/fastRandomForest/DataCache.java
@@ -302,8 +302,8 @@ public class DataCache {
   /**
    * Returns a random number generator. The initial seed of the random
    * number generator depends on the given seed and the contents of the
-   * sortedIndices array (a single attribute is picked, its sortedIndices
-   * converted to String and a hashcode computed).
+   * sortedIndices array (a single attribute is picked, a hashcode of its
+   * sortedIndices is computed).
    *
    * @param seed the given seed
    * @return the random number generator
@@ -311,9 +311,7 @@ public class DataCache {
   public Random getRandomNumberGenerator(long seed) {
 
     Random r = new Random(seed);
-    long dataSignature
-            = Arrays.toString( sortedIndices[ r.nextInt( numAttributes ) ] )
-            .hashCode();
+    long dataSignature = Arrays.hashCode( sortedIndices[ r.nextInt( numAttributes ) ] );
     r.setSeed( dataSignature + seed );
     return r;
     


### PR DESCRIPTION
The pull requests deals with a seed computation in method `DataCache#getRandomNumberGenerator`. The method creates a new random generator, sets its seed, and returns the instance. 

However, there seems to be unnecessarily complex logic for computing the seed:
1. A random attribute is selected
2. A String is composed from the sorted indices of the selected attribute
3. A hashcode is computed from the String
4. The seed is finally given by adding the hashcode and some other given seed

My goal is to avoid the String conversion while keeping the randomness. The proposed change is quite small but should be more time & memory efficient than the current implementation.