### PR TITLE
Change the inference from recursion to a while loop

### DIFF
--- a/src/main/java/hr/irb/fastRandomForest/FastRandomTree.java
+++ b/src/main/java/hr/irb/fastRandomForest/FastRandomTree.java
@@ -240,55 +240,38 @@ class FastRandomTree
    */
   @Override
   public double[] distributionForInstance(Instance instance) throws Exception {
+    FastRandomTree currentTree = this;
 
-    double[] returnedDist = null;
-
-    if (m_Attribute > -1) {  // ============================ node is not a leaf
-
-      if (instance.isMissing(m_Attribute)) {  // ---------------- missing value
-
-        returnedDist = new double[m_MotherForest.m_Info.numClasses()];
+    while (currentTree.m_Attribute > -1) { //while the current tree is not a leaf
+      if (instance.isMissing(currentTree.m_Attribute)) { // missing value
+        double[] returnedDist = new double[m_MotherForest.m_Info.numClasses()];
         // split instance up
-        for (int i = 0; i < m_Successors.length; i++) {
-          double[] help = m_Successors[i].distributionForInstance(instance);
+        for (int i = 0; i < currentTree.m_Successors.length; i++) {
+          double[] help = currentTree.m_Successors[i].distributionForInstance(instance);
           if (help != null) {
             for (int j = 0; j < help.length; j++) {
-              returnedDist[j] += m_Prop[i] * help[j];
+              returnedDist[j] += currentTree.m_Prop[i] * help[j];
             }
           }
         }
-
-      } else if (m_MotherForest.m_Info
-        .attribute(m_Attribute).isNominal()) { // ------ nominal
-
-        //returnedDist = m_Successors[(int) instance.value(m_Attribute)]
-        //        .distributionForInstance(instance);
-
+        return returnedDist;
+      } else if (m_MotherForest.m_Info.attribute(currentTree.m_Attribute).isNominal()) { //nominal attributes
         // 0.99: new - binary splits (also) for nominal attributes
-        if ( instance.value(m_Attribute) == m_SplitPoint ) {
-          returnedDist = m_Successors[0].distributionForInstance(instance);
+        if (instance.value(currentTree.m_Attribute) == currentTree.m_SplitPoint) {
+          currentTree = currentTree.m_Successors[0];
         } else {
-          returnedDist = m_Successors[1].distributionForInstance(instance);
+          currentTree = currentTree.m_Successors[1];
         }
-
-
-      } else { // ------------------------------------------ numeric attributes
-
-        if (instance.value(m_Attribute) < m_SplitPoint) {
-          returnedDist = m_Successors[0].distributionForInstance(instance);
+      } else { //numeric attributes
+        if (instance.value(currentTree.m_Attribute) < currentTree.m_SplitPoint) {
+          currentTree = currentTree.m_Successors[0];
         } else {
-          returnedDist = m_Successors[1].distributionForInstance(instance);
+          currentTree = currentTree.m_Successors[1];
         }
       }
-
-      return returnedDist;
-
-    } else { // =============================================== node is a leaf
-
-      return m_ClassProbs;
-
     }
 
+    return currentTree.m_ClassProbs;
   }
 
 
@@ -307,54 +290,38 @@ class FastRandomTree
    * @throws Exception if computation fails
    */
   public double[] distributionForInstanceInDataCache(DataCache data, int instIdx) {
+    FastRandomTree currentTree = this;
 
-    double[] returnedDist = null;
-
-    if (m_Attribute > -1) {  // ============================ node is not a leaf
-
-      if ( data.isValueMissing(m_Attribute, instIdx) ) {  // ---------------- missing value
-
-        returnedDist = new double[m_MotherForest.m_Info.numClasses()];
+    while (currentTree.m_Attribute > -1) { //while the current tree is not a leaf
+      if (data.isValueMissing(currentTree.m_Attribute, instIdx)) { // missing value
+        double[] returnedDist = new double[m_MotherForest.m_Info.numClasses()];
         // split instance up
-        for (int i = 0; i < m_Successors.length; i++) {
-          double[] help = m_Successors[i].distributionForInstanceInDataCache(data, instIdx);
+        for (int i = 0; i < currentTree.m_Successors.length; i++) {
+          double[] help = currentTree.m_Successors[i].distributionForInstanceInDataCache(data, instIdx);
           if (help != null) {
             for (int j = 0; j < help.length; j++) {
-              returnedDist[j] += m_Prop[i] * help[j];
+              returnedDist[j] += currentTree.m_Prop[i] * help[j];
             }
           }
         }
-
-      } else if ( data.isAttrNominal(m_Attribute) ) { // ------ nominal
-
-        //returnedDist = m_Successors[(int) instance.value(m_Attribute)]
-        //        .distributionForInstance(instance);
-
+        return returnedDist;
+      } else if (data.isAttrNominal(currentTree.m_Attribute)) { //nominal attributes
         // 0.99: new - binary splits (also) for nominal attributes
-        if ( data.vals[m_Attribute][instIdx] == m_SplitPoint ) {
-          returnedDist = m_Successors[0].distributionForInstanceInDataCache(data, instIdx);
+        if (data.vals[currentTree.m_Attribute][instIdx] == currentTree.m_SplitPoint) {
+          currentTree = currentTree.m_Successors[0];
         } else {
-          returnedDist = m_Successors[1].distributionForInstanceInDataCache(data, instIdx);
+          currentTree = currentTree.m_Successors[1];
         }
-
-
-      } else { // ------------------------------------------ numeric attributes
-
-        if ( data.vals[m_Attribute][instIdx] < m_SplitPoint) {
-          returnedDist = m_Successors[0].distributionForInstanceInDataCache(data, instIdx);
+      } else { //numeric attributes
+        if (data.vals[currentTree.m_Attribute][instIdx] < currentTree.m_SplitPoint) {
+          currentTree = currentTree.m_Successors[0];
         } else {
-          returnedDist = m_Successors[1].distributionForInstanceInDataCache(data, instIdx);
+          currentTree = currentTree.m_Successors[1];
         }
       }
-
-      return returnedDist;
-
-    } else { // =============================================== node is a leaf
-
-      return m_ClassProbs;
-
     }
 
+    return currentTree.m_ClassProbs;
   }
 
 


### PR DESCRIPTION
The methods `FastRandomTree#distributionForInstance` and `FastRandomTree#distributionForInstanceInDataCache` are currently written using recursion. My goal is to speed up the inference by turning the recursion into a loop. Since it is mostly tail recursion, it is a fairly easy task. *Note:* My proposal still contains a recursive call, but only when the attribute used for splitting is missing in the instance.

I tested the proposed implementation, and it seems correct (i.e., does the same thing as the recursive version) – although my instances do not contain missing values. 

I also somehow measured how the speed changed. The inference on my data used to take ~15 seconds; now it takes ~12 seconds. Perhaps, Java (openjdk version "1.8.0_232") does not perform tail-recursion optimizations. 

Unfortunately, I did not come up with more "systematic" and convincing benchmark so maybe a little more effort could be invested into this.